### PR TITLE
Add Ruff configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,5 @@
 # Editor-Autom-tico
+
+Repository to demonstrate automated linting setup with [Ruff](https://docs.astral.sh/ruff/).
+
+Run `ruff check .` to analyze the code.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,11 @@
+[tool.ruff]
+line-length = 88
+
+[tool.ruff.lint]
+select = ["E", "F", "I"]
+ignore = []
+
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+


### PR DESCRIPTION
## Summary
- add Ruff config in `pyproject.toml`
- document Ruff usage in README

## Testing
- `ruff check .`

------
https://chatgpt.com/codex/tasks/task_e_6844d45077488320875515f43cdb513d