### PR TITLE
Fix audio output mapping

### DIFF
--- a/video_processing_logic.py
+++ b/video_processing_logic.py
@@ -318,10 +318,14 @@ def _run_single_item_processing(params: Dict[str, Any], progress_queue: Queue, c
         audio_to_mix.append("[music]")
 
     if len(audio_to_mix) > 1:
-        filter_complex_parts.append(f"{''.join(audio_to_mix)}amix=inputs={len(audio_to_mix)}:duration=first:dropout_transition=3[aout]")
+        filter_complex_parts.append(
+            f"{''.join(audio_to_mix)}amix=inputs={len(audio_to_mix)}:duration=first:dropout_transition=3[aout]"
+        )
         map_args.extend(["-map", "[aout]"])
     elif len(audio_to_mix) == 1:
-        map_args.extend(["-map", f"[{audio_input_count}:a]"])
+        # When only one audio source is present, map the filtered output
+        # (e.g. '[narrated]' or '[music]') instead of the raw input index.
+        map_args.extend(["-map", audio_to_mix[0]])
     
     video_filters = []
     force_reencode = not (source_w == target_w and source_h == target_h)


### PR DESCRIPTION
## Summary
- fix filter output mapping when there is a single audio input

## Testing
- `python3 -m py_compile video_processing_logic.py`
- Manual processing tests for `video_single`, `image_folder`, and `batch` modes

------
https://chatgpt.com/codex/tasks/task_e_6844d4e0d02083209046f04996666b3b