### PR TITLE
Fix audio mapping and processing callback

### DIFF
--- a/main.py
+++ b/main.py
@@ -649,11 +649,18 @@ class VideoEditorApp:
             self.update_status_textbox("Cancelamento solicitado... Aguardando a tarefa terminar.", tag="warning")
 
     def _processing_thread_done_callback(self, future):
-        try: future.result()
+        try:
+            # Garante que exceções sejam registradas corretamente. A função
+            # process_entrypoint envia sua própria mensagem de finalização, por
+            # isso não precisamos colocar 'finish' aqui em condições normais.
+            future.result()
         except Exception as e:
-            logger.error(f"Exceção na thread de processamento: {e}", exc_info=True)
+            logger.error(
+                f"Exceção na thread de processamento: {e}", exc_info=True
+            )
             self.progress_queue.put(("status", f"Erro fatal na thread: {e}", "error"))
-        finally:
+            # Em casos de exceção pode ser que nenhuma mensagem de finalização
+            # seja enviada, então notificamos a interface com falha.
             self.progress_queue.put(("finish", False))
 
     def _finalize_processing_ui_state(self, success: bool):

--- a/video_processing_logic.py
+++ b/video_processing_logic.py
@@ -321,7 +321,11 @@ def _run_single_item_processing(params: Dict[str, Any], progress_queue: Queue, c
         filter_complex_parts.append(f"{''.join(audio_to_mix)}amix=inputs={len(audio_to_mix)}:duration=first:dropout_transition=3[aout]")
         map_args.extend(["-map", "[aout]"])
     elif len(audio_to_mix) == 1:
-        map_args.extend(["-map", f"[{audio_input_count}:a]"])
+        # Quando há apenas uma trilha de áudio, devemos mapear a saída
+        # filtrada (ex.: volume ajustado) e não o índice bruto do arquivo
+        # de entrada. "audio_to_mix" contém exatamente o rótulo do filtro
+        # correspondente ("[narrated]" ou "[music]").
+        map_args.extend(["-map", audio_to_mix[0]])
     
     video_filters = []
     force_reencode = not (source_w == target_w and source_h == target_h)


### PR DESCRIPTION
## Summary
- fix audio mapping when only one audio track is provided
- avoid duplicate finish messages from worker thread

## Testing
- `python -m py_compile main.py video_processing_logic.py`
- `flake8 main.py video_processing_logic.py` *(fails: many style warnings)*
- `python main.py --help` *(fails: no display)*

------
https://chatgpt.com/codex/tasks/task_e_6844d70b6c388320a98ce4ecf4b212d4