### PR TITLE
Fix ffmpeg invocation for long commands on Windows

### DIFF
--- a/video_processing_logic.py
+++ b/video_processing_logic.py
@@ -88,17 +88,11 @@ def _execute_ffmpeg(cmd: List[str], duration: float, progress_callback: Callable
     creation_flags = subprocess.CREATE_NO_WINDOW if platform.system() == "Windows" else 0
 
     cmd_str = subprocess.list2cmdline(cmd_with_progress)
+
     if platform.system() == "Windows" and len(cmd_str) > 8000:
-        # On Windows the command line length is limited (~8k). Use FFmpeg's
-        # argument file feature to avoid this limitation. The arguments are
-        # written to a separate file which ffmpeg will load.
-        args_only = ' '.join(subprocess.list2cmdline([arg]) for arg in cmd_with_progress[1:])
-        with tempfile.NamedTemporaryFile(delete=False, suffix=".args", mode="w", encoding="utf-8") as f:
-            f.write(args_only)
-            arg_file = f.name
-        logger.debug(f"[{log_prefix}] Comando muito longo, usando arquivo de argumentos {arg_file}")
-        cmd_exec = [cmd_with_progress[0], f"@{arg_file}"]
-    elif platform.system() == "Windows" and len(cmd_str) > 32000:
+        # Em ambientes Windows, o comprimento máximo da linha de comando é
+        # limitado. Para contornar o problema de forma confiável, gravamos todo
+        # o comando em um arquivo .bat e executamos esse script.
         with tempfile.NamedTemporaryFile(delete=False, suffix=".bat", mode="w", encoding="utf-8") as f:
             f.write(cmd_str)
             script_path = f.name


### PR DESCRIPTION
## Summary
- ensure ffmpeg is run via a temporary batch file when the command length exceeds Windows limits
- adjust `_execute_ffmpeg` to drop the argument file approach

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844e78699848320a1259688bce0b10c